### PR TITLE
[Mycosnp] Update input Params

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -4,9 +4,9 @@ workflows:
    subclass: WDL
    primaryDescriptorPath: /workflows/wf_mycosnp_variants.wdl
    testParameterFiles:
-    - empty.json
+    - /tests/inputs/empty.json
  - name: MycoSNP_Tree
    subclass: WDL
    primaryDescriptorPath: /workflows/wf_mycosnp_tree.wdl
    testParameterFiles:
-    - empty.json
+    - /tests/inputs/empty.json

--- a/tasks/task_mycosnp_tree.wdl
+++ b/tasks/task_mycosnp_tree.wdl
@@ -5,12 +5,12 @@ task mycosnptree {
     Array[File] vcf
     Array[File] vcf_index
     String docker="quay.io/theiagen/mycosnp:1.4" # this doesnt match the 1.5 version in the command
-    String? strain="B11205" # Optional, defaults to clade-specific reference 
-    String? accession="GCA_016772135" # Optional, defaults to clade-specific reference 
+    String strain="B11205" # Optional, defaults to clade-specific reference 
+    String accession="GCA_016772135" # Optional, defaults to clade-specific reference 
     Int disk_size = 50
     Int cpu = 4
     Int memory = 32
-    Int? sample_ploidy = 2  # Optional, default ploidy is 2
+    Int? sample_ploidy
   }
   command <<<
     set -euo pipefail
@@ -49,9 +49,10 @@ task mycosnptree {
         --add_vcf_file ../samples.csv \
         --ref_dir /reference/~{accession} \
         --strain ~{strain} \
-        ~{if defined(sample_ploidy) then '--sample_ploidy ' + sample_ploidy else ''}
+        ~{if defined(sample_ploidy) then '--sample_ploidy ' + sample_ploidy else ''} \
         --iqtree \
         --publish_dir_mode copy \
+        --max_cpus ~{cpu} \
         --tmpdir ${TMPDIR:-/tmp}; then
       # Everything finished, pack up the results and clean up
       rm -rf .nextflow/ work/

--- a/tasks/task_mycosnp_tree.wdl
+++ b/tasks/task_mycosnp_tree.wdl
@@ -10,8 +10,8 @@ task mycosnptree {
     Int disk_size = 50
     Int cpu = 4
     Int memory = 32
-    # Optional: User-provided reference tar file or fasta file
-    File? fasta
+    # Optional: User-provided reference fasta file .fa
+    File? ref_fasta
   }
   command <<<
     date | tee DATE
@@ -37,9 +37,9 @@ task mycosnptree {
     done
 
    # Set reference FASTA
-    if [[ -n "~{fasta}" && -f "~{fasta}" ]]; then 
-        echo "Using user-provided FASTA: ~{fasta}" 
-        cp ~{fasta} /reference/custom_ref.fa 
+    if [[ -n "~{ref_fasta}" && -f "~{ref_fasta}" ]]; then 
+        echo "Using user-provided FASTA: ~{ref_fasta}" 
+        cp ~{ref_fasta} /reference/custom_ref.fa 
         ref_param="--fasta /reference/custom_ref.fa"
         ref_name="custom_ref.fa"
     else 

--- a/tasks/task_mycosnp_tree.wdl
+++ b/tasks/task_mycosnp_tree.wdl
@@ -12,8 +12,6 @@ task mycosnptree {
     Int memory = 32
     # Optional: User-provided reference tar file or fasta file
     File? fasta
-    # Tree building method (choose one: iqtree, fasttree, rapidnj)
-    String tree_method = "iqtree" 
   }
   command <<<
     date | tee DATE
@@ -30,10 +28,6 @@ task mycosnptree {
       echo "VCF array (length: $vcf_array_len) and VCF index array (length: $vcf_index_array_len) are of unequal length." >&2
       exit 1
     fi
-
-    #debug vcf arrays
-    echo "VCF array: ${vcf_array[@]}"
-    echo "VCF index array: ${vcf_index_array[@]}"
 
     # Make sample FOFN
     touch samples.csv
@@ -68,16 +62,15 @@ task mycosnptree {
     if nextflow run /mycosnp-nf/main.nf \
         --add_vcf_file ../samples.csv \
         $ref_param \
-        --${tree_method} \
+        --iqtree \
         --publish_dir_mode copy \
         --max_cpus ~{cpu} \
-        --max_memory ~{memory}GB \
-        --tmpdir ${TMPDIR:-/tmp}; then
+        --max_memory "~{memory}GB" \
+        --tmpdir "${TMPDIR:-/tmp}"; then
       rm -rf .nextflow/ work/
       cd ..
-      tar -cf - mycosnptree/ | gzip -n --best  > mycosnptree.tar.gz
+      tar -cf - mycosnptree/ 2>/dev/null | gzip -n --best > mycosnptree.tar.gz || echo "Warning: tar failed"
     else
-      # Run failed
       exit 1
     fi
   >>>

--- a/tasks/task_mycosnp_tree.wdl
+++ b/tasks/task_mycosnp_tree.wdl
@@ -4,9 +4,9 @@ task mycosnptree {
   input {
     Array[File] vcf
     Array[File] vcf_index
-    String docker="quay.io/theiagen/mycosnp:1.4" # this doesnt match the 1.5 version in the command
-    String strain="B11205" # Optional, defaults to clade-specific reference 
-    String accession="GCA_016772135" # Optional, defaults to clade-specific reference 
+    String docker = "us-docker.pkg.dev/general-theiagen/theiagen/mycosnp:1.5"
+    String strain = "B11205" # Optional, defaults to clade-specific reference 
+    String accession = "GCA_016772135" # Optional, defaults to clade-specific reference 
     Int disk_size = 50
     Int cpu = 4
     Int memory = 32
@@ -53,6 +53,7 @@ task mycosnptree {
         --iqtree \
         --publish_dir_mode copy \
         --max_cpus ~{cpu} \
+        --max_memory "~{memory}.GB"
         --tmpdir ${TMPDIR:-/tmp}; then
       # Everything finished, pack up the results and clean up
       rm -rf .nextflow/ work/

--- a/tasks/task_mycosnp_tree.wdl
+++ b/tasks/task_mycosnp_tree.wdl
@@ -5,8 +5,8 @@ task mycosnptree {
     Array[File] vcf
     Array[File] vcf_index
     String docker = "quay.io/theiagen/mycosnp:1.4"
-    String strain = "B11205" 
-    String accession = "GCA_016772135" # Optional, defaults to accession reference 
+    String strain = "B11205" # this is not used by the NF pipeline as an input but internally is the reference strain
+    String reference = "GCA_016772135" # Optional, defaults to accession reference 
     Int disk_size = 50
     Int cpu = 4
     Int memory = 32
@@ -44,7 +44,7 @@ task mycosnptree {
     cd mycosnptree
     if nextflow run /mycosnp-nf/main.nf \
         --add_vcf_file ../samples.csv \
-        --ref_dir /reference/~{accession} \
+        --ref_dir /reference/~{reference} \
         --iqtree \
         --publish_dir_mode copy \
         --max_cpus ~{cpu} \
@@ -63,7 +63,7 @@ task mycosnptree {
     String mycosnptree_docker = docker
     String analysis_date = read_string("DATE")
     String reference_strain = strain
-    String reference_accession = accession
+    String reference_name = reference
     File mycosnptree_rapidnj_tree = "mycosnptree/results/combined/phylogeny/rapidnj/rapidnj_phylogeny.nh"
     File mycosnptree_fasttree_tree = "mycosnptree/results/combined/phylogeny/fasttree/fasttree_phylogeny.nh"
     File mycosnptree_iqtree_tree = "mycosnptree/results/combined/phylogeny/iqtree/iqtree_phylogeny.nh"

--- a/tasks/task_mycosnp_tree.wdl
+++ b/tasks/task_mycosnp_tree.wdl
@@ -38,7 +38,12 @@ task mycosnptree {
       echo -e "${vcf}" >> samples.csv
     done
 
-    # Validate tree_method input
+    # Validate tree_method input and assign a default if empty
+    if [[ -z "~{tree_method}" ]]; then
+        echo "WARNING: No tree method specified, defaulting to iqtree."
+        tree_method="iqtree"
+    fi
+
     valid_tree_methods=("iqtree" "fasttree" "rapidnj")
     if [[ ! " ${valid_tree_methods[@]} " =~ " ${tree_method} " ]]; then
       echo "ERROR: Invalid tree method '${tree_method}'. Must be one of: iqtree, fasttree, rapidnj." >&2

--- a/tasks/task_mycosnp_tree.wdl
+++ b/tasks/task_mycosnp_tree.wdl
@@ -43,9 +43,9 @@ task mycosnptree {
         ref_param="--fasta /reference/custom_ref.fa"
         ref_name="custom_ref.fa"
     else 
-        echo "Using built-in reference: /reference/~{reference}.fa"
-        ref_param="--fasta /reference/~{reference}.fa"
-        ref_name="~{reference}.fa"
+        echo "Using built-in reference directory: /reference/~{reference}"
+        ref_param="--ref_dir /reference/~{reference}"
+        ref_name="~{reference}"
     fi 
 
     echo "$ref_name" | tee REFERENCE_NAME  # Save reference name for output

--- a/tasks/task_mycosnp_tree.wdl
+++ b/tasks/task_mycosnp_tree.wdl
@@ -31,6 +31,10 @@ task mycosnptree {
       exit 1
     fi
 
+    #debug vcf arrays
+    echo "VCF array: ${vcf_array[@]}"
+    echo "VCF index array: ${vcf_index_array[@]}"
+
     # Make sample FOFN
     touch samples.csv
     for index in ${!vcf_array[@]}; do

--- a/tasks/task_mycosnp_tree.wdl
+++ b/tasks/task_mycosnp_tree.wdl
@@ -10,11 +10,8 @@ task mycosnptree {
     Int disk_size = 50
     Int cpu = 4
     Int memory = 32
-    Int? sample_ploidy
   }
   command <<<
-    set -euo pipefail
-
     date | tee DATE
     # mycosnp-nf does not have a version output
     echo "mycosnp-nf 1.5" | tee MYCOSNPTREE_VERSION
@@ -48,13 +45,10 @@ task mycosnptree {
     if nextflow run /mycosnp-nf/main.nf \
         --add_vcf_file ../samples.csv \
         --ref_dir /reference/~{accession} \
-        ~{if defined(sample_ploidy) then '--sample_ploidy ' + sample_ploidy else ''} \
         --iqtree \
         --publish_dir_mode copy \
         --max_cpus ~{cpu} \
-        --max_memory "~{memory}.GB"
-        --tmpdir "${TMPDIR:-/tmp}"; then
-
+        --tmpdir ${TMPDIR:-/tmp}; then
       # Everything finished, pack up the results and clean up
       rm -rf .nextflow/ work/
       cd ..

--- a/tasks/task_mycosnp_tree.wdl
+++ b/tasks/task_mycosnp_tree.wdl
@@ -4,12 +4,16 @@ task mycosnptree {
   input {
     Array[File] vcf
     Array[File] vcf_index
-    String docker="quay.io/theiagen/mycosnp:1.4"
-    String strain="B11205"
-    String accession="GCA_016772135"
+    String docker="quay.io/theiagen/mycosnp:1.4" # this doesnt match the 1.5 version in the command
+    String? strain="B11205" # Optional, defaults to clade-specific reference 
+    String? accession="GCA_016772135" # Optional, defaults to clade-specific reference 
     Int disk_size = 50
+    Int cpu = 4
+    Int memory = 32
   }
   command <<<
+    set -euo pipefail
+    
     date | tee DATE
     # mycosnp-nf does not have a version output
     echo "mycosnp-nf 1.5" | tee MYCOSNPTREE_VERSION
@@ -43,6 +47,7 @@ task mycosnptree {
     if nextflow run /mycosnp-nf/main.nf \
         --add_vcf_file ../samples.csv \
         --ref_dir /reference/~{accession} \
+        --strain ~{strain} \
         --iqtree \
         --publish_dir_mode copy \
         --tmpdir ${TMPDIR:-/tmp}; then
@@ -71,9 +76,9 @@ task mycosnptree {
   }
   runtime {
     docker: "~{docker}"
-    memory: "32 GB"
-    cpu: 4
-    disks: "local-disk ~{disk_size} SSD"
+    memory: "~{memory} GB"
+    cpu: cpu
+    disks: "local-disk " + disk_size + " SSD"
     maxRetries: 3
     preemptible: 0
   }

--- a/tasks/task_mycosnp_tree.wdl
+++ b/tasks/task_mycosnp_tree.wdl
@@ -38,12 +38,7 @@ task mycosnptree {
       echo -e "${vcf}" >> samples.csv
     done
 
-    # Validate tree_method input and assign a default if empty
-    if [[ -z "~{tree_method}" ]]; then
-        echo "WARNING: No tree method specified, defaulting to iqtree."
-        tree_method="iqtree"
-    fi
-
+    # Tree method validation
     valid_tree_methods=("iqtree" "fasttree" "rapidnj")
     if [[ ! " ${valid_tree_methods[@]} " =~ " ${tree_method} " ]]; then
       echo "ERROR: Invalid tree method '${tree_method}'. Must be one of: iqtree, fasttree, rapidnj." >&2

--- a/tasks/task_mycosnp_tree.wdl
+++ b/tasks/task_mycosnp_tree.wdl
@@ -5,7 +5,7 @@ task mycosnptree {
     Array[File] vcf
     Array[File] vcf_index
     String docker = "quay.io/theiagen/mycosnp:1.4"
-    String strain = "B11205" # Optional, defaults to clade-specific reference 
+    String strain = "B11205" 
     String accession = "GCA_016772135" # Optional, defaults to accession reference 
     Int disk_size = 50
     Int cpu = 4

--- a/tasks/task_mycosnp_tree.wdl
+++ b/tasks/task_mycosnp_tree.wdl
@@ -10,6 +10,8 @@ task mycosnptree {
     Int disk_size = 50
     Int cpu = 4
     Int memory = 32
+    Int sample_ploidy
+    Int min_depth = 10
   }
   command <<<
     date | tee DATE
@@ -49,6 +51,8 @@ task mycosnptree {
         --publish_dir_mode copy \
         --max_cpus ~{cpu} \
         --max_memory ~{memory}GB \
+        --sample_ploidy ~{sample_ploidy} \
+        --min_depth ~{min_depth} \
         --tmpdir ${TMPDIR:-/tmp}; then
       # Everything finished, pack up the results and clean up
       rm -rf .nextflow/ work/

--- a/tasks/task_mycosnp_tree.wdl
+++ b/tasks/task_mycosnp_tree.wdl
@@ -4,7 +4,7 @@ task mycosnptree {
   input {
     Array[File] vcf
     Array[File] vcf_index
-    String docker = "quay.io/theiagen/mycosnp:1.4"
+    String docker = "us-docker.pkg.dev/general-theiagen/theiagen/mycosnp:1.5"
     String strain = "B11205" # this is not used by the NF pipeline as an input but internally is the reference strain
     String reference = "GCA_016772135" # Optional, defaults to accession reference 
     Int disk_size = 50
@@ -37,13 +37,6 @@ task mycosnptree {
       vcf=${vcf_array[$index]}
       echo -e "${vcf}" >> samples.csv
     done
-
-    # Tree method validation
-    valid_tree_methods=("iqtree" "fasttree" "rapidnj")
-    if [[ ! " ${valid_tree_methods[@]} " =~ " ${tree_method} " ]]; then
-      echo "ERROR: Invalid tree method '${tree_method}'. Must be one of: iqtree, fasttree, rapidnj." >&2
-      exit 1
-    fi
 
    # Set reference FASTA
     if [[ -n "~{fasta}" && -f "~{fasta}" ]]; then 

--- a/tasks/task_mycosnp_tree.wdl
+++ b/tasks/task_mycosnp_tree.wdl
@@ -10,10 +10,11 @@ task mycosnptree {
     Int disk_size = 50
     Int cpu = 4
     Int memory = 32
+    Int? sample_ploidy = 2  # Optional, default ploidy is 2
   }
   command <<<
     set -euo pipefail
-    
+
     date | tee DATE
     # mycosnp-nf does not have a version output
     echo "mycosnp-nf 1.5" | tee MYCOSNPTREE_VERSION
@@ -48,6 +49,7 @@ task mycosnptree {
         --add_vcf_file ../samples.csv \
         --ref_dir /reference/~{accession} \
         --strain ~{strain} \
+        ~{if defined(sample_ploidy) then '--sample_ploidy ' + sample_ploidy else ''}
         --iqtree \
         --publish_dir_mode copy \
         --tmpdir ${TMPDIR:-/tmp}; then

--- a/tasks/task_mycosnp_tree.wdl
+++ b/tasks/task_mycosnp_tree.wdl
@@ -4,7 +4,7 @@ task mycosnptree {
   input {
     Array[File] vcf
     Array[File] vcf_index
-    String docker = "us-docker.pkg.dev/general-theiagen/theiagen/mycosnp:1.5"
+    String docker = "quay.io/theiagen/mycosnp:1.4"
     String strain = "B11205" # Optional, defaults to clade-specific reference 
     String accession = "GCA_016772135" # Optional, defaults to accession reference 
     Int disk_size = 50

--- a/tasks/task_mycosnp_tree.wdl
+++ b/tasks/task_mycosnp_tree.wdl
@@ -6,7 +6,7 @@ task mycosnptree {
     Array[File] vcf_index
     String docker = "us-docker.pkg.dev/general-theiagen/theiagen/mycosnp:1.5"
     String strain = "B11205" # Optional, defaults to clade-specific reference 
-    String accession = "GCA_016772135" # Optional, defaults to clade-specific reference 
+    String accession = "GCA_016772135" # Optional, defaults to accession reference 
     Int disk_size = 50
     Int cpu = 4
     Int memory = 32
@@ -48,13 +48,13 @@ task mycosnptree {
     if nextflow run /mycosnp-nf/main.nf \
         --add_vcf_file ../samples.csv \
         --ref_dir /reference/~{accession} \
-        --strain ~{strain} \
         ~{if defined(sample_ploidy) then '--sample_ploidy ' + sample_ploidy else ''} \
         --iqtree \
         --publish_dir_mode copy \
         --max_cpus ~{cpu} \
         --max_memory "~{memory}.GB"
-        --tmpdir ${TMPDIR:-/tmp}; then
+        --tmpdir "${TMPDIR:-/tmp}"; then
+
       # Everything finished, pack up the results and clean up
       rm -rf .nextflow/ work/
       cd ..

--- a/tasks/task_mycosnp_tree.wdl
+++ b/tasks/task_mycosnp_tree.wdl
@@ -48,6 +48,7 @@ task mycosnptree {
         --iqtree \
         --publish_dir_mode copy \
         --max_cpus ~{cpu} \
+        --max_memory ~{memory}GB \
         --tmpdir ${TMPDIR:-/tmp}; then
       # Everything finished, pack up the results and clean up
       rm -rf .nextflow/ work/

--- a/tasks/task_mycosnp_variants.wdl
+++ b/tasks/task_mycosnp_variants.wdl
@@ -8,7 +8,7 @@ task mycosnp {
     String docker = "quay.io/theiagen/mycosnp:1.5"
     String strain = "B11205"
     String accession = "GCA_016772135"
-    Int memory = 64
+    Int memory = 16
     Int cpu = 8
     Int disk_size = 100
     Int? coverage
@@ -18,6 +18,8 @@ task mycosnp {
     Boolean debug = false
   }
   command <<<
+    set -euo pipefail
+
     date | tee DATE
     # mycosnp-nf does not have a version output
     echo "mycosnp-nf 1.5" | tee MYCOSNP_VERSION
@@ -45,6 +47,7 @@ task mycosnp {
         --skip_phylogeny \
         --tmpdir "${TMPDIR:-/tmp}" \
         --max_cpus ~{cpu} \
+        --min_depth ~{min_depth} \
         --max_memory "~{memory}.GB"; then
         
       # Everything finished, pack up the results

--- a/tasks/task_mycosnp_variants.wdl
+++ b/tasks/task_mycosnp_variants.wdl
@@ -15,11 +15,28 @@ task mycosnp {
     Int sample_ploidy
     Int min_depth = 10
     Boolean debug = false
+
+    # Optional: User-defined reference files
+    File? ref_masked_fasta
+    File? ref_fai
+    File? ref_dict
+    File? ref_bwa
   }
   command <<<
     date | tee DATE
     # mycosnp-nf does not have a version output
     echo "mycosnp-nf 1.5" | tee MYCOSNP_VERSION
+
+    # Validate custom reference inputs
+    if [[ -n "~{ref_masked_fasta}" || -n "~{ref_fai}" || -n "~{ref_dict}" || -n "~{ref_bwa}" ]]; then
+        if [[ -z "~{ref_masked_fasta}" || -z "~{ref_fai}" || -z "~{ref_dict}" || -z "~{ref_bwa}" ]]; then
+            echo "ERROR: If providing a custom reference, you must provide all required files (FASTA, FAI, DICT, BWA)." >&2
+            exit 1
+        fi
+        ref_dir_flag="--ref_masked_fasta ~{ref_masked_fasta} --ref_fai ~{ref_fai} --ref_dict ~{ref_dict} --ref_bwa ~{ref_bwa}"
+    else
+        ref_dir_flag="--ref_dir /reference/~{reference}"
+    fi
 
     # Make sample FOFN
     echo "sample,fastq_1,fastq_2" > sample.csv

--- a/tasks/task_mycosnp_variants.wdl
+++ b/tasks/task_mycosnp_variants.wdl
@@ -25,18 +25,18 @@ task mycosnp {
     # mycosnp-nf does not have a version output
     echo "mycosnp-nf 1.5" | tee MYCOSNP_VERSION
 
-    # Determine the reference directory
-    if [[ -n "~{ref_tar}" && -f "~{ref_tar}" ]]; then
+    # Set reference directory
+    if [[ -n "~{ref_tar}" && -f "~{ref_tar}" && "~{ref_tar}" == *.tar.gz ]]; then
         echo "Extracting user-provided reference archive..."
         mkdir -p /reference/custom_ref
-        tar -xzvf ~{ref_tar} -C /reference/custom_ref
+        tar -xzvf ~{ref_tar} -C /reference/custom_ref || { echo "ERROR: Extraction failed"; exit 1; }
         ref_dir="--ref_dir /reference/custom_ref/"
-        ref_name=$(basename "~{ref_tar}" .tar.gz) # Extract name without .tar.gz
+        ref_name=$(basename "~{ref_tar}" .tar.gz)
 
     elif [[ -n "~{fasta}" && -f "~{fasta}" ]]; then
         echo "Using user-provided FASTA: ~{fasta}"
         cp ~{fasta} /reference/custom_ref.fasta
-        ref_dir="--fasta /reference/custom_ref.fasta"
+        ref_dir="--fasta /reference/custom_ref.fa"
         ref_name=$(basename "~{fasta}")
 
     else
@@ -61,7 +61,7 @@ task mycosnp {
     cd ~{samplename}
      if nextflow run /mycosnp-nf/main.nf \
         --input ../sample.csv \
-        "$ref_param" \
+        $ref_param \
         --publish_dir_mode copy \
         --sample_ploidy ~{sample_ploidy} \
         --min_depth ~{min_depth} \

--- a/tasks/task_mycosnp_variants.wdl
+++ b/tasks/task_mycosnp_variants.wdl
@@ -7,10 +7,11 @@ task mycosnp {
     String samplename
     String docker = "quay.io/theiagen/mycosnp:1.5"
     String strain = "B11205"
-    String accession = "GCA_016772135"
+    String accession = "GCA_016772135" # Optional, defaults to clade-specific reference
     Int memory = 64
     Int cpu = 8
     Int? coverage
+    Int? sample_ploidy
     Int min_depth = 10
     Int disk_size = 100
     Boolean debug = false
@@ -36,7 +37,7 @@ task mycosnp {
         --input ../sample.csv \
         --ref_dir /reference/~{accession} \
         --publish_dir_mode copy \
-        --strain ~{strain} \
+        ~{if defined(sample_ploidy) then '--sample_ploidy ' + sample_ploidy else ''} \
         --min_depth ~{min_depth} \
         --skip_phylogeny \
         --tmpdir "${TMPDIR:-/tmp}" \

--- a/tasks/task_mycosnp_variants.wdl
+++ b/tasks/task_mycosnp_variants.wdl
@@ -29,7 +29,7 @@ task mycosnp {
     if [[ -n "~{ref_tar}" && -f "~{ref_tar}" && "~{ref_tar}" == *.tar.gz ]]; then
         echo "Extracting user-provided reference archive..."
         mkdir -p /reference/custom_ref
-        tar -xzvf ~{ref_tar} -C /reference/custom_ref || { echo "ERROR: Extraction failed"; exit 1; }
+        tar -xzf ~{ref_tar} --strip-components=1 -C /reference/custom_ref
         ref_param="--ref_dir /reference/custom_ref/"
         ref_name=$(basename "~{ref_tar}" .tar.gz)
 

--- a/tasks/task_mycosnp_variants.wdl
+++ b/tasks/task_mycosnp_variants.wdl
@@ -35,7 +35,7 @@ task mycosnp {
 
     elif [[ -n "~{fasta}" && -f "~{fasta}" ]]; then
         echo "Using user-provided FASTA: ~{fasta}"
-        cp ~{fasta} /reference/custom_ref.fasta
+        cp ~{fasta} /reference/custom_ref.fa
         ref_dir="--fasta /reference/custom_ref.fa"
         ref_name=$(basename "~{fasta}")
 

--- a/tasks/task_mycosnp_variants.wdl
+++ b/tasks/task_mycosnp_variants.wdl
@@ -12,7 +12,7 @@ task mycosnp {
     Int cpu = 8
     Int disk_size = 100
     Int? coverage
-    Int? sample_ploidy
+    Int sample_ploidy
     Int min_depth = 10
     Boolean debug = false
   }
@@ -37,12 +37,13 @@ task mycosnp {
         --input ../sample.csv \
         --ref_dir /reference/~{reference} \
         --publish_dir_mode copy \
-        ~{if defined(sample_ploidy) then '--sample_ploidy ' + sample_ploidy else ''} \
+        --sample_ploidy ~{sample_ploidy} \
         --min_depth ~{min_depth} \
         --skip_phylogeny \
         --tmpdir "${TMPDIR:-/tmp}" \
         --max_cpus ~{cpu} \
-        --max_memory "~{memory}.GB" ~{'--coverage ' + coverage}; then
+        --max_memory "~{memory}.GB" 
+        ~{'--coverage ' + coverage}; then
         
       # Everything finished, pack up the results
       if [[ "~{debug}" == "false" ]]; then

--- a/tasks/task_mycosnp_variants.wdl
+++ b/tasks/task_mycosnp_variants.wdl
@@ -36,6 +36,8 @@ task mycosnp {
         --input ../sample.csv \
         --ref_dir /reference/~{accession} \
         --publish_dir_mode copy \
+        --strain ~{strain} \
+        --min_depth ~{min_depth} \
         --skip_phylogeny \
         --tmpdir "${TMPDIR:-/tmp}" \
         --max_cpus ~{cpu} \

--- a/tasks/task_mycosnp_variants.wdl
+++ b/tasks/task_mycosnp_variants.wdl
@@ -25,28 +25,27 @@ task mycosnp {
     # mycosnp-nf does not have a version output
     echo "mycosnp-nf 1.5" | tee MYCOSNP_VERSION
 
-    # Determine reference mode
-    if [[ -n "~{fasta}" && -f "~{fasta}" ]]; then
-        echo "Using FASTA input: ~{fasta}"
-        ref_param="--fasta ~{fasta}"
-        ref_name=$(basename ~{fasta})
-    
-    elif [[ -n "~{ref_tar}" && -f "~{ref_tar}" ]]; then
+    # Determine the reference directory
+    if [[ -n "~{ref_tar}" && -f "~{ref_tar}" ]]; then
         echo "Extracting user-provided reference archive..."
-        mkdir -p /reference
-        tar -xzvf ~{ref_tar} -C /reference --overwrite
-        ref_dir="/reference/$(basename ~{ref_tar} .tar.gz)"
-        ref_param="--ref_dir $ref_dir"
-        ref_name=$(basename ~{ref_tar} .tar.gz)
-    
+        mkdir -p /reference/custom_ref
+        tar -xzvf ~{ref_tar} -C /reference/custom_ref
+        ref_dir="--ref_dir /reference/custom_ref/"
+        ref_name=$(basename "~{ref_tar}" .tar.gz) # Extract name without .tar.gz
+
+    elif [[ -n "~{fasta}" && -f "~{fasta}" ]]; then
+        echo "Using user-provided FASTA: ~{fasta}"
+        cp ~{fasta} /reference/custom_ref.fasta
+        ref_dir="--fasta /reference/custom_ref.fasta"
+        ref_name=$(basename "~{fasta}")
+
     else
         echo "Using predefined reference: /reference/~{reference}"
-        ref_dir="/reference/~{reference}"
-        ref_param="--ref_dir $ref_dir"
+        ref_dir="--ref_dir /reference/~{reference}"
         ref_name="~{reference}"
     fi
 
-    echo "$ref_name" | tee REFERENCE_NAME
+    echo "$ref_name" | tee REFERENCE_NAME  # Save reference name for output
 
     # Create sample input file
     echo "sample,fastq_1,fastq_2" > sample.csv

--- a/tasks/task_mycosnp_variants.wdl
+++ b/tasks/task_mycosnp_variants.wdl
@@ -8,18 +8,14 @@ task mycosnp {
     String docker = "quay.io/theiagen/mycosnp:1.5"
     String strain = "B11205"
     String accession = "GCA_016772135"
-    Int memory = 16
+    Int memory = 64
     Int cpu = 8
-    Int disk_size = 100
     Int? coverage
-    Int? sample_ploidy
     Int min_depth = 10
-    
+    Int disk_size = 100
     Boolean debug = false
   }
   command <<<
-    set -euo pipefail
-
     date | tee DATE
     # mycosnp-nf does not have a version output
     echo "mycosnp-nf 1.5" | tee MYCOSNP_VERSION
@@ -40,15 +36,10 @@ task mycosnp {
         --input ../sample.csv \
         --ref_dir /reference/~{accession} \
         --publish_dir_mode copy \
-        --strain ~{strain} \
-        ~{if defined(coverage) then '--coverage ' + coverage else ''} \
-        ~{if defined(min_depth) then '--min_depth ' + min_depth else ''} \
-        ~{if defined(sample_ploidy) then '--sample_ploidy ' + sample_ploidy else ''} \
         --skip_phylogeny \
         --tmpdir "${TMPDIR:-/tmp}" \
         --max_cpus ~{cpu} \
-        --min_depth ~{min_depth} \
-        --max_memory "~{memory}.GB"; then
+        --max_memory "~{memory}.GB" ~{'--coverage ' + coverage}; then
         
       # Everything finished, pack up the results
       if [[ "~{debug}" == "false" ]]; then

--- a/tasks/task_mycosnp_variants.wdl
+++ b/tasks/task_mycosnp_variants.wdl
@@ -41,7 +41,7 @@ task mycosnp {
 
     else
         echo "Using predefined reference: /reference/~{reference}"
-        ref_dir="--ref_dir /reference/~{reference}"
+        ref_param="--ref_dir /reference/"~{reference}
         ref_name="~{reference}"
     fi
 

--- a/tasks/task_mycosnp_variants.wdl
+++ b/tasks/task_mycosnp_variants.wdl
@@ -36,7 +36,7 @@ task mycosnp {
     elif [[ -n "~{fasta}" && -f "~{fasta}" ]]; then
         echo "Using user-provided FASTA: ~{fasta}"
         cp ~{fasta} /reference/custom_ref.fa
-        ref_dir="--fasta /reference/custom_ref.fa"
+        ref_param="--fasta /reference/custom_ref.fa"
         ref_name=$(basename "~{fasta}")
 
     else
@@ -46,6 +46,7 @@ task mycosnp {
     fi
 
     echo "$ref_name" | tee REFERENCE_NAME  # Save reference name for output
+    echo "Final reference param: $ref_param"  # Log reference parameter
 
     # Create sample input file
     echo "sample,fastq_1,fastq_2" > sample.csv

--- a/tasks/task_mycosnp_variants.wdl
+++ b/tasks/task_mycosnp_variants.wdl
@@ -6,8 +6,8 @@ task mycosnp {
     File read2
     String samplename
     String docker = "us-docker.pkg.dev/general-theiagen/theiagen/mycosnp:1.5"
-    String strain = "B11205"
-    String accession = "GCA_016772135" # Optional, defaults to clade-specific reference
+    String strain = "B11205" # this is not used by the NF pipeline as an input but internally is the reference strain so we output
+    String reference = "GCA_016772135" # Optional, defaults to clade-specific reference
     Int memory = 64
     Int cpu = 8
     Int disk_size = 100
@@ -35,7 +35,7 @@ task mycosnp {
     cd ~{samplename}
     if nextflow run /mycosnp-nf/main.nf \
         --input ../sample.csv \
-        --ref_dir /reference/~{accession} \
+        --ref_dir /reference/~{reference} \
         --publish_dir_mode copy \
         ~{if defined(sample_ploidy) then '--sample_ploidy ' + sample_ploidy else ''} \
         --min_depth ~{min_depth} \
@@ -86,7 +86,7 @@ task mycosnp {
     String mycosnp_docker = docker
     String analysis_date = read_string("DATE")
     String reference_strain = strain
-    String reference_accession = accession
+    String reference_name = reference
     Int reads_before_trimming = read_int("MYCOSNP_READS_BEFORE_TRIMMING")
     Float gc_before_trimming = read_float("MYCOSNP_GC_BEFORE_TRIMMING")
     Float average_q_score_before_trimming = read_float("MYCOSNP_AVERAGE_Q_SCORE_BEFORE_TRIMMING")

--- a/tasks/task_mycosnp_variants.wdl
+++ b/tasks/task_mycosnp_variants.wdl
@@ -5,10 +5,10 @@ task mycosnp {
     File read1
     File read2
     String samplename
-    String docker = "quay.io/theiagen/mycosnp:1.5"
+    String docker = "us-docker.pkg.dev/general-theiagen/theiagen/mycosnp:1.5"
     String strain = "B11205"
     String accession = "GCA_016772135" # Optional, defaults to clade-specific reference
-    Int memory = 64
+    Int memory = 64s
     Int cpu = 8
     Int? coverage
     Int? sample_ploidy

--- a/tasks/task_mycosnp_variants.wdl
+++ b/tasks/task_mycosnp_variants.wdl
@@ -18,7 +18,7 @@ task mycosnp {
 
     # Optional: User-provided reference tar file or fasta file
     File? ref_tar
-    File? fasta
+    File? ref_fasta
   }
   command <<<
     date | tee DATE
@@ -33,11 +33,11 @@ task mycosnp {
         ref_param="--ref_dir /reference/custom_ref/"
         ref_name=$(basename "~{ref_tar}" .tar.gz)
 
-    elif [[ -n "~{fasta}" && -f "~{fasta}" ]]; then
-        echo "Using user-provided FASTA: ~{fasta}"
-        cp ~{fasta} /reference/custom_ref.fa
+    elif [[ -n "~{ref_fasta}" && -f "~{ref_fasta}" ]]; then
+        echo "Using user-provided FASTA: ~{ref_fasta}"
+        cp ~{ref_fasta} /reference/custom_ref.fa
         ref_param="--fasta /reference/custom_ref.fa"
-        ref_name=$(basename "~{fasta}")
+        ref_name=$(basename "~{ref_fasta}")
 
     else
         echo "Using predefined reference: /reference/~{reference}"

--- a/tasks/task_mycosnp_variants.wdl
+++ b/tasks/task_mycosnp_variants.wdl
@@ -11,7 +11,7 @@ task mycosnp {
     Int memory = 64
     Int cpu = 8
     Int disk_size = 100
-    Int? coverage
+    Int coverage = 0
     Int? sample_ploidy
     Int min_depth = 10
     Boolean debug = false
@@ -30,7 +30,7 @@ task mycosnp {
         mkdir -p /reference/custom_ref
         tar -xzvf ~{ref_tar} -C /reference/custom_ref --strip-components=1 --overwrite
         ref_dir="/reference/custom_ref"
-        ref_name=$(basename "~{ref_tar}" .tar.gz)  # Extract filename without .tar.gz
+        ref_name="$(basename ~{ref_tar} .tar.gz)"  # Extract filename without .tar.gz
     else
         echo "Using predefined reference: /reference/~{reference}"
         ref_dir="/reference/~{reference}"
@@ -38,7 +38,7 @@ task mycosnp {
     fi
 
     echo "$ref_name" | tee REFERENCE_NAME  # Save reference name for output
-    
+
     # Create sample input file
     echo "sample,fastq_1,fastq_2" > sample.csv
     echo "~{samplename},~{read1},~{read2}" >> sample.csv
@@ -63,7 +63,7 @@ task mycosnp {
         --max_memory "~{memory}.GB" 
         ~{'--coverage ' + coverage}; then
         
-      # Everything finished, pack up the results
+       # Everything finished, pack up the results
       if [[ "~{debug}" == "false" ]]; then
         # not in debug mode, clean up
         rm -rf .nextflow/ work/

--- a/tasks/task_mycosnp_variants.wdl
+++ b/tasks/task_mycosnp_variants.wdl
@@ -29,13 +29,14 @@ task mycosnp {
         echo "Extracting user-provided reference archive..."
         mkdir -p /reference
         tar -xzvf ~{ref_tar} -C /reference --overwrite
-        ref_dir="/reference/$(tar -tzf ~{ref_tar} | head -1 | cut -d '/' -f1)"  # Capture extracted top-level folder
-        ref_name=$(basename "~{ref_tar}" .tar.gz)
+        ref_dir="/reference/$(basename ~{ref_tar} .tar.gz)"  # Use tar filename without .tar.gz as the folder name
+        ref_name=$(basename ~{ref_tar} .tar.gz)
     else
         echo "Using predefined reference: /reference/~{reference}"
         ref_dir="/reference/~{reference}"
         ref_name="~{reference}"
     fi
+
 
     echo "$ref_name" | tee REFERENCE_NAME  # Save reference name for output
 

--- a/tasks/task_mycosnp_variants.wdl
+++ b/tasks/task_mycosnp_variants.wdl
@@ -8,12 +8,12 @@ task mycosnp {
     String docker = "us-docker.pkg.dev/general-theiagen/theiagen/mycosnp:1.5"
     String strain = "B11205"
     String accession = "GCA_016772135" # Optional, defaults to clade-specific reference
-    Int memory = 64s
+    Int memory = 64
     Int cpu = 8
+    Int disk_size = 100
     Int? coverage
     Int? sample_ploidy
     Int min_depth = 10
-    Int disk_size = 100
     Boolean debug = false
   }
   command <<<

--- a/tasks/task_mycosnp_variants.wdl
+++ b/tasks/task_mycosnp_variants.wdl
@@ -10,9 +10,11 @@ task mycosnp {
     String accession = "GCA_016772135"
     Int memory = 64
     Int cpu = 8
-    Int? coverage
-    Int min_depth = 10
     Int disk_size = 100
+    Int? coverage
+    Int? sample_ploidy
+    Int min_depth = 10
+    
     Boolean debug = false
   }
   command <<<
@@ -36,10 +38,14 @@ task mycosnp {
         --input ../sample.csv \
         --ref_dir /reference/~{accession} \
         --publish_dir_mode copy \
+        --strain ~{strain} \
+        ~{if defined(coverage) then '--coverage ' + coverage else ''} \
+        ~{if defined(min_depth) then '--min_depth ' + min_depth else ''} \
+        ~{if defined(sample_ploidy) then '--sample_ploidy ' + sample_ploidy else ''} \
         --skip_phylogeny \
         --tmpdir "${TMPDIR:-/tmp}" \
         --max_cpus ~{cpu} \
-        --max_memory "~{memory}.GB" ~{'--coverage ' + coverage}; then
+        --max_memory "~{memory}.GB"; then
         
       # Everything finished, pack up the results
       if [[ "~{debug}" == "false" ]]; then

--- a/tasks/task_mycosnp_variants.wdl
+++ b/tasks/task_mycosnp_variants.wdl
@@ -30,7 +30,7 @@ task mycosnp {
         echo "Extracting user-provided reference archive..."
         mkdir -p /reference/custom_ref
         tar -xzvf ~{ref_tar} -C /reference/custom_ref || { echo "ERROR: Extraction failed"; exit 1; }
-        ref_dir="--ref_dir /reference/custom_ref/"
+        ref_param="--ref_dir /reference/custom_ref/"
         ref_name=$(basename "~{ref_tar}" .tar.gz)
 
     elif [[ -n "~{fasta}" && -f "~{fasta}" ]]; then

--- a/tests/inputs/wf_mycosnp_variants.json
+++ b/tests/inputs/wf_mycosnp_variants.json
@@ -2,7 +2,7 @@
     "mycosnp_variants.samplename": "test",
     "mycosnp_variants.read1": "tests/fastqs/test_R1.fastq.gz",
     "mycosnp_variants.read2": "tests/fastqs/test_R2.fastq.gz",
-    "mycosnp_variants.mycosnp.accession": "test",
+    "mycosnp_variants.mycosnp.reference": "test",
     "mycosnp_variants.mycosnp.min_depth": 5,
     "mycosnp_variants.mycosnp.cpu": 2,
     "mycosnp_variants.mycosnp.memory": 6

--- a/tests/workflows/test_wf_mycosnp_variants.yml
+++ b/tests/workflows/test_wf_mycosnp_variants.yml
@@ -317,9 +317,9 @@
     - path: miniwdl_run/inputs.json
     - path: miniwdl_run/outputs.json
     - path: miniwdl_run/wdl/tasks/task_mycosnp_variants.wdl
-      md5sum: ba602f7b1e4a7bd4f878606cb0fbbe5a
+      md5sum: 0f65fa570dfed0f6cf9afb68db255b58
     - path: miniwdl_run/wdl/tasks/task_versioning.wdl
       md5sum: a17beb7504b76c9074736e5052702230
     - path: miniwdl_run/wdl/workflows/wf_mycosnp_variants.wdl
-      md5sum: 1a1136e487afb8f6341e8f5e6739eb63
+      md5sum: e83c1c54813a776e614ddae21036b092
     - path: miniwdl_run/workflow.log

--- a/tests/workflows/test_wf_mycosnp_variants.yml
+++ b/tests/workflows/test_wf_mycosnp_variants.yml
@@ -18,7 +18,7 @@
     - wf_mycosnp_variants_miniwdl
   files:
     - path: miniwdl_run/call-mycosnp/command
-      md5sum: dee1f918b42901cc26a7c35defcc785a
+      md5sum: 07365a61d5b5e2c406859c4445c96a5e
     - path: miniwdl_run/call-mycosnp/inputs.json
     - path: miniwdl_run/call-mycosnp/outputs.json
     - path: miniwdl_run/call-mycosnp/stderr.txt
@@ -194,7 +194,7 @@
     - path: miniwdl_run/call-mycosnp/work/test/results/multiqc/multiqc_plots/svg/mqc_samtools_alignment_plot_1_pc.svg
     - path: miniwdl_run/call-mycosnp/work/test/results/multiqc/multiqc_report.html
     - path: miniwdl_run/call-mycosnp/work/test/results/pipeline_info/software_versions.yml
-      md5sum: 3339eb73b448baba0a7ca3d04a5a4b75
+      md5sum: 7e4d33177535f70aaa4039cf07b6adbe
     - path: miniwdl_run/call-mycosnp/work/test/results/samples/test/faqcs/qa.test.base_content.txt
       md5sum: ca40f814008224f24e196813979cd7e5
     - path: miniwdl_run/call-mycosnp/work/test/results/samples/test/faqcs/qa.test.for_qual_histogram.txt
@@ -309,7 +309,7 @@
     - path: miniwdl_run/call-mycosnp/work/test/results/stats/samtools_idxstats/test.idxstats
       md5sum: 41ac5c1643eac749c95c87ae032eedd9
     - path: miniwdl_run/call-mycosnp/work/test/results/stats/samtools_stats/test.stats
-      md5sum: 44444ac4662f98ee7322f6c32798a01a
+      md5sum: 37458e96ef9bd35556f1c8a84ac345cf
     - path: miniwdl_run/call-mycosnp/work/tqc_report.txt
       md5sum: 7caf1d8410ca529e734089d8cf161731
     - path: miniwdl_run/call-version_capture/inputs.json
@@ -318,9 +318,9 @@
     - path: miniwdl_run/inputs.json
     - path: miniwdl_run/outputs.json
     - path: miniwdl_run/wdl/tasks/task_mycosnp_variants.wdl
-      md5sum: 047eae352d211a3a6110e30959bbd71f
+      md5sum: ba602f7b1e4a7bd4f878606cb0fbbe5a
     - path: miniwdl_run/wdl/tasks/task_versioning.wdl
       md5sum: a17beb7504b76c9074736e5052702230
     - path: miniwdl_run/wdl/workflows/wf_mycosnp_variants.wdl
-      md5sum: 84f2c216eb5928c7e662050385866de4
+      md5sum: 1a1136e487afb8f6341e8f5e6739eb63
     - path: miniwdl_run/workflow.log

--- a/tests/workflows/test_wf_mycosnp_variants.yml
+++ b/tests/workflows/test_wf_mycosnp_variants.yml
@@ -4,8 +4,7 @@
     - wf_mycosnp_variants
     - wf_mycosnp_variants_cromwell
   files:
-    - path: log.err
-      contains: ["Successfully released change log lock", "INFO", "WORKFLOW_METADATA_SUMMARY_ENTRY", "liquibase"]
+    - path: log.err # file is empty, so don't check for strings within, just for presence
     - path: log.out
       contains: ["workflow finished with status 'Succeeded'", "mycosnp_variants", "Done"]
     - path: metadata.json

--- a/workflows/wf_mycosnp_tree.wdl
+++ b/workflows/wf_mycosnp_tree.wdl
@@ -10,15 +10,11 @@ workflow mycosnp_tree {
   input {
     Array[File] vcf
     Array[File] vcf_index
-    String? strain
-    String? accession
   }
   call mycosnptree_nf.mycosnptree {
     input:
       vcf = vcf,
-      vcf_index = vcf_index,
-      strain = strain,
-      accession = accession,
+      vcf_index = vcf_index
   }
   call versioning.version_capture{
     input:
@@ -30,9 +26,8 @@ workflow mycosnp_tree {
     #MycoSNP QC and Assembly
     String mycosnp_version = mycosnptree.mycosnptree_version
     String mycosnp_docker = mycosnptree.mycosnptree_docker
-    String analysis_date = mycosnptree.analysis_date
-    String? reference_strain = mycosnptree.reference_strain
-    String? reference_accession = mycosnptree.reference_accession
+    String reference_strain = mycosnptree.reference_strain
+    String reference_accession = mycosnptree.reference_accession
     File mycosnp_rapidnj_tree = mycosnptree.mycosnptree_rapidnj_tree 
     File mycosnp_fastree_tree = mycosnptree.mycosnptree_fasttree_tree
     File mycosnp_iqtree_tree = mycosnptree.mycosnptree_iqtree_tree

--- a/workflows/wf_mycosnp_tree.wdl
+++ b/workflows/wf_mycosnp_tree.wdl
@@ -10,14 +10,14 @@ workflow mycosnp_tree {
   input {
     Array[File] vcf
     Array[File] vcf_index
-    File? fasta  # Optional reference FASTA input
+    File? ref_fasta  # Optional reference FASTA input
 
   }
   call mycosnptree_nf.mycosnptree {
     input:
       vcf = vcf,
       vcf_index = vcf_index,
-      fasta = fasta
+      ref_fasta = ref_fasta
   }
   call versioning.version_capture{
     input:

--- a/workflows/wf_mycosnp_tree.wdl
+++ b/workflows/wf_mycosnp_tree.wdl
@@ -27,7 +27,7 @@ workflow mycosnp_tree {
     String mycosnp_version = mycosnptree.mycosnptree_version
     String mycosnp_docker = mycosnptree.mycosnptree_docker
     String reference_strain = mycosnptree.reference_strain
-    String reference_accession = mycosnptree.reference_accession
+    String reference_name = mycosnptree.reference_name
     File mycosnp_rapidnj_tree = mycosnptree.mycosnptree_rapidnj_tree 
     File mycosnp_fastree_tree = mycosnptree.mycosnptree_fasttree_tree
     File mycosnp_iqtree_tree = mycosnptree.mycosnptree_iqtree_tree

--- a/workflows/wf_mycosnp_tree.wdl
+++ b/workflows/wf_mycosnp_tree.wdl
@@ -10,11 +10,15 @@ workflow mycosnp_tree {
   input {
     Array[File] vcf
     Array[File] vcf_index
+    String? strain
+    String? accession
   }
   call mycosnptree_nf.mycosnptree {
     input:
       vcf = vcf,
-      vcf_index = vcf_index
+      vcf_index = vcf_index,
+      strain = strain,
+      accession = accession,
   }
   call versioning.version_capture{
     input:
@@ -27,8 +31,8 @@ workflow mycosnp_tree {
     String mycosnp_version = mycosnptree.mycosnptree_version
     String mycosnp_docker = mycosnptree.mycosnptree_docker
     String analysis_date = mycosnptree.analysis_date
-    String reference_strain = mycosnptree.reference_strain
-    String reference_accession = mycosnptree.reference_accession
+    String? reference_strain = mycosnptree.reference_strain
+    String? reference_accession = mycosnptree.reference_accession
     File mycosnp_rapidnj_tree = mycosnptree.mycosnptree_rapidnj_tree 
     File mycosnp_fastree_tree = mycosnptree.mycosnptree_fasttree_tree
     File mycosnp_iqtree_tree = mycosnptree.mycosnptree_iqtree_tree

--- a/workflows/wf_mycosnp_tree.wdl
+++ b/workflows/wf_mycosnp_tree.wdl
@@ -10,11 +10,14 @@ workflow mycosnp_tree {
   input {
     Array[File] vcf
     Array[File] vcf_index
+    File? fasta  # Optional reference FASTA input
+
   }
   call mycosnptree_nf.mycosnptree {
     input:
       vcf = vcf,
-      vcf_index = vcf_index
+      vcf_index = vcf_index,
+      fasta = fasta
   }
   call versioning.version_capture{
     input:

--- a/workflows/wf_mycosnp_variants.wdl
+++ b/workflows/wf_mycosnp_variants.wdl
@@ -11,14 +11,16 @@ workflow mycosnp_variants {
     File read1
     File read2
     String samplename
-    File? ref_tar #Optional user-defined reference tar file
+    File? ref_tar # Optional user-defined reference tar file
+    File? fasta # Optional: User-defined FASTA file (will be indexed)
   }
   call mycosnp_nf.mycosnp {
     input:
       read1 = read1,
       read2 = read2,
       samplename = samplename,
-      ref_tar = ref_tar
+      ref_tar = ref_tar,
+      fasta = fasta
   }
   call versioning.version_capture{
     input:

--- a/workflows/wf_mycosnp_variants.wdl
+++ b/workflows/wf_mycosnp_variants.wdl
@@ -11,12 +11,21 @@ workflow mycosnp_variants {
     File read1
     File read2
     String samplename
+    # Optional: User-defined reference files (must provide all if using custom reference)
+    File? ref_masked_fasta
+    File? ref_fai
+    File? ref_dict
+    File? ref_bwa
   }
   call mycosnp_nf.mycosnp {
     input:
       read1 = read1,
       read2 = read2,
       samplename = samplename,
+      ref_masked_fasta = ref_masked_fasta,
+      ref_fai = ref_fai,
+      ref_dict = ref_dict,
+      ref_bwa = ref_bwa
   }
   call versioning.version_capture{
     input:

--- a/workflows/wf_mycosnp_variants.wdl
+++ b/workflows/wf_mycosnp_variants.wdl
@@ -11,12 +11,16 @@ workflow mycosnp_variants {
     File    read1
     File    read2
     String  samplename
+    String? strain
+    String? accession
   }
   call mycosnp_nf.mycosnp {
     input:
       read1 = read1,
       read2 = read2,
-      samplename = samplename
+      samplename = samplename,
+      strain = strain,
+      accession = accession
   }
   call versioning.version_capture{
     input:

--- a/workflows/wf_mycosnp_variants.wdl
+++ b/workflows/wf_mycosnp_variants.wdl
@@ -30,7 +30,7 @@ workflow mycosnp_variants {
     String mycosnp_docker = mycosnp.mycosnp_docker
     String analysis_date = mycosnp.analysis_date
     String reference_strain = mycosnp.reference_strain
-    String reference_accession = mycosnp.reference_accession
+    String reference_name = mycosnp.reference_name
     Int reads_before_trimming = mycosnp.reads_before_trimming
     Float gc_before_trimming = mycosnp.gc_before_trimming
     Float average_q_score_before_trimming = mycosnp.average_q_score_before_trimming

--- a/workflows/wf_mycosnp_variants.wdl
+++ b/workflows/wf_mycosnp_variants.wdl
@@ -11,16 +11,12 @@ workflow mycosnp_variants {
     File read1
     File read2
     String samplename
-    String? strain
-    String? accession
   }
   call mycosnp_nf.mycosnp {
     input:
       read1 = read1,
       read2 = read2,
       samplename = samplename,
-      strain = strain,
-      accession = accession
   }
   call versioning.version_capture{
     input:

--- a/workflows/wf_mycosnp_variants.wdl
+++ b/workflows/wf_mycosnp_variants.wdl
@@ -12,7 +12,7 @@ workflow mycosnp_variants {
     File read2
     String samplename
     File? ref_tar # Optional user-defined reference tar file
-    File? fasta # Optional: User-defined FASTA file (will be indexed)
+    File? ref_fasta # Optional: User-defined FASTA file (will be indexed)
   }
   call mycosnp_nf.mycosnp {
     input:
@@ -20,7 +20,7 @@ workflow mycosnp_variants {
       read2 = read2,
       samplename = samplename,
       ref_tar = ref_tar,
-      fasta = fasta
+      ref_fasta = ref_fasta
   }
   call versioning.version_capture{
     input:

--- a/workflows/wf_mycosnp_variants.wdl
+++ b/workflows/wf_mycosnp_variants.wdl
@@ -11,21 +11,14 @@ workflow mycosnp_variants {
     File read1
     File read2
     String samplename
-    # Optional: User-defined reference files (must provide all if using custom reference)
-    File? ref_masked_fasta
-    File? ref_fai
-    File? ref_dict
-    File? ref_bwa
+    File? ref_tar #Optional user-defined reference tar file
   }
   call mycosnp_nf.mycosnp {
     input:
       read1 = read1,
       read2 = read2,
       samplename = samplename,
-      ref_masked_fasta = ref_masked_fasta,
-      ref_fai = ref_fai,
-      ref_dict = ref_dict,
-      ref_bwa = ref_bwa
+      ref_tar = ref_tar
   }
   call versioning.version_capture{
     input:

--- a/workflows/wf_mycosnp_variants.wdl
+++ b/workflows/wf_mycosnp_variants.wdl
@@ -8,9 +8,9 @@ workflow mycosnp_variants {
     description: "A WDL wrapper around the qc, processing and variant calling components of mycosnp-nf."
   }
   input {
-    File    read1
-    File    read2
-    String  samplename
+    File read1
+    File read2
+    String samplename
     String? strain
     String? accession
   }


### PR DESCRIPTION
Note Documentation will be updated as part of a separate PR

This PR closes #4 #5 
🗑️ This dev branch should be deleted after merging to main.

## :brain: Summary
Update MycoSNP WDL: Standardized Inputs, Added sample_ploidy, min_depth, max_cpus, max_memory, aligned runtime parameters and Updated Reference Handling

The user can now:
- use the reference datasets [here ](https://github.com/theiagen/mycosnp-wdl/tree/main/data/reference)using the `reference` input
- use a ref_tar file for custom set of reference files for mycosnp variants this includes dir of bwa/dict/fai and masked ref files.
- Use a custom fasta file the user provides - this uses the --fasta input to NF and will add an additional step of index the genome for bwa and other tools - i.e will take a little longer to run

## :zap: Impacted Workflows/Tasks
- `task_mycosnp_tree.wdl`
- `task_mycosnp_variants.wdl`

workflows updated for tree and variants

This PR may lead to different results in pre-existing outputs:  No

This PR uses an element that could cause duplicate runs to have different results: No

## :hammer_and_wrench: Changes
- Renamed `accession` → reference for consistency with MycoSNP Nextflow (aligns with `references/clades` in `data/reference/`).
- Docker image for MycoSNP Variantsmoved to Theiagen's Artifact Registry and updated Mycosnp tree from v1.4 to 1.5: `us-docker.pkg.dev/general-theiagen/theiagen/mycosnp:1.5`
- Added `sample_ploidy` (default: 1) and min_depth (default: 10) as explicit inputs (previously hardcoded in Nextflow) for Variants task
- Exposed `max_cpus` and `max_memory` as user-defined parameters for better resource control.
- Aligned runtime parameters to PHB style for consistency across workflows.
- Updated reference parameter handling in mycosnp_tree:
      -  If a user provides a FASTA file, it is copied and used with `--fasta /reference/custom_ref.fa`
      -  If no FASTA is provided, `--ref_dir /reference/~{reference}` is used instead.
     
### :gear: Algorithm
No algorithm changes only added inputs and renamed `accession` to `reference`

### ➡️ Inputs
- Added sample_ploidy (default: 1) to allow explicit control over variant calling assumptions.
- Added min_depth (default: 10) for user-defined variant filtering.
- Added max-cpu and max memory so they can be used in the nextflow.
- Renamed accession → reference for clarity in the input schema.
- Updated reference parameter in mycosnp_tree to use --ref_dir instead of --fasta for built-in references.

 Previously, sample_ploidy and min_depth were hardcoded in Nextflow. They are now explicitly user-configurable.

### ⬅️ Outputs
Accession is now named reference for clarity

## :test_tube: Testing

### MycosnpVariants

Successfully ran MycoSNP Variants setting reference to "Clade3" ([here](https://app.terra.bio/#workspaces/theiagen-training-workspaces/Theiagen_FCombe_sandbox/job_history/332b650a-a6af-4262-9544-46703007e405)) 

Successfully ran Mycosnp_variants with a custom fasta file ([here](https://app.terra.bio/#workspaces/theiagen-training-workspaces/Theiagen_FCombe_sandbox/job_history/0940e6af-08f8-43fb-9b72-9cfdf7309449))

Successful test with a tar file of the reference files - custom ref_tar ([here](https://app.terra.bio/#workspaces/theiagen-training-workspaces/Theiagen_FCombe_sandbox/job_history/203a73e8-0dd8-4bf7-a229-394ccd10282d/524e484f-4da0-48e0-82c1-210418dda096))

### MycosnpTree
Successfully ran MycoSNP Tree with a custom fasta file ([here](https://app.terra.bio/#workspaces/theiagen-training-workspaces/Theiagen_FCombe_sandbox/job_history/97be9dbd-0e55-4dae-9d89-81d1f634499c](https://app.terra.bio/#workspaces/theiagen-training-workspaces/Theiagen_FCombe_sandbox/job_history/0f9a4f7a-4a8f-4b51-a163-4bbf7f8d19b1)))

Successfully ran MycoSNP tree with reference set to "Clade3" in reference dataset ([here](https://app.terra.bio/#workspaces/theiagen-training-workspaces/Theiagen_FCombe_sandbox/job_history/56d3e533-e46b-49fb-b0ec-92df1a1daaec))

confirmed NF log file that the optional parameters are accepted

### Suggested Scenarios for Reviewer to Test
Run MycoSNP Variants and verify that the new parameters (sample_ploidy, min_depth, max_cpus, max_memory) are correctly passed.

Check custom fasta passes to variants ot tree workflows

## :microscope: Final Developer Checklist
<!-- Please mark boxes [X] -->
- [x] The workflow/task has been tested and results, including file contents, are as anticipated
- [x] The CI/CD has been adjusted and tests are passing (Theiagen developers)
- [x] Code changes follow the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-51b66a47dde54c798f35d673fff80249)
- [x] Documentation and/or workflow diagrams have been updated if applicable (See PR [6](https://github.com/theiagen/mycosnp-wdl/pull/6))

## 🎯 Reviewer Checklist
<!--  Indicate NA when not applicable  -->
- [ ] All changed results have been confirmed
- [x] You have tested the PR appropriately (see the [testing guide](https://theiagen.notion.site/PR-Testing-Guide-Determining-Appropriate-Levels-of-Testing-4764e98a6aeb460185039c0896714590) for more information)
- [x] All code adheres to the [style guide](https://theiagen.notion.site/Style-Guide-WDL-Workflow-Development-51b66a47dde54c798f35d673fff80249)
- [x] MD5 sums have been updated
- [x] The PR author has addressed all comments
- [ ] The documentation has been updated

