### PR TITLE
Al update gha

### DIFF
--- a/.github/workflows/miniwdl-check.yml
+++ b/.github/workflows/miniwdl-check.yml
@@ -20,10 +20,10 @@ jobs:
       workflows_files: ${{ steps.filter.outputs.wf_files }}
     steps:
       # Checkout the repo
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       # Select wdl files with changes
-      - uses: dorny/paths-filter@v2
+      - uses: dorny/paths-filter@v3
         id: filter
         with:
           filters: |
@@ -43,11 +43,11 @@ jobs:
         wf: ${{ fromJson(needs.changes.outputs.workflows_files) }}
     steps:
       # Checkout the repo
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       # Install a version of Python3
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: "3.x"
       

--- a/.github/workflows/pytest-workflows.yml
+++ b/.github/workflows/pytest-workflows.yml
@@ -19,10 +19,10 @@ jobs:
       workflows: ${{ steps.filter.outputs.changes }}
     steps:
       # Checkout the repo
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       # Select workflows with changes
-      - uses: dorny/paths-filter@v2
+      - uses: dorny/paths-filter@v3
         id: filter
         with:
           filters: "tests/config/pytest_filter.yml"
@@ -45,11 +45,11 @@ jobs:
     steps:
       # Checkout the repo
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       # Setup Miniconda3
       - name: Setup miniconda
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v3
         with:
           activate-environment: actions
           auto-activate-base: false
@@ -64,7 +64,7 @@ jobs:
 
       - name: Upload logs on failure
         if: failure()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: logs-${{ matrix.engine }}
           path: |


### PR DESCRIPTION
This PR updates actions used for CI of this repo, as the previously implemented version (v2) of GHA is now deprecated. 