### PR TITLE
remove parentheses from output

### DIFF
--- a/tasks/task_mycosnp_variants.wdl
+++ b/tasks/task_mycosnp_variants.wdl
@@ -94,7 +94,7 @@ task mycosnp {
     grep "^Average Q Score Before Trimming" tqc_report.txt | cut -f2 | tee MYCOSNP_AVERAGE_Q_SCORE_BEFORE_TRIMMING
     grep "^Reference Length Coverage Before Trimming" tqc_report.txt | cut -f2 | tee MYCOSNP_REFERENCE_LENGTH_COVERAGE_BEFORE_TRIMMING
     grep "^Reads After Trimming" tqc_report.txt | cut -f2 | cut -f1 -d " " | tee MYCOSNP_READS_AFTER_TRIMMING
-    grep "^Reads After Trimming" tqc_report.txt | cut -f2 | cut -f2 -d " " | sed -e "s/(//" | tee MYCOSNP_READS_AFTER_TRIMMING_PERCENT
+    grep "^Reads After Trimming" tqc_report.txt  | awk '{print $4}' | tee MYCOSNP_READS_AFTER_TRIMMING_PERCENT
     grep "^Paired Reads After Trimming" tqc_report.txt | cut -f2 | cut -f1 -d " " | tee MYCOSNP_PAIRED_READS_AFTER_TRIMMING
     grep "^Paired Reads After Trimming" tqc_report.txt | cut -f2 | cut -f2 -d " " | sed -e "s/(//" | tee MYCOSNP_PAIRED_READS_AFTER_TRIMMING_PERCENT
     grep "^Unpaired Reads After Trimming" tqc_report.txt | cut -f2 | cut -f1 -d " " | tee MYCOSNP_UNPAIRED_READS_AFTER_TRIMMING

--- a/tasks/task_mycosnp_variants.wdl
+++ b/tasks/task_mycosnp_variants.wdl
@@ -94,7 +94,7 @@ task mycosnp {
     grep "^Average Q Score Before Trimming" tqc_report.txt | cut -f2 | tee MYCOSNP_AVERAGE_Q_SCORE_BEFORE_TRIMMING
     grep "^Reference Length Coverage Before Trimming" tqc_report.txt | cut -f2 | tee MYCOSNP_REFERENCE_LENGTH_COVERAGE_BEFORE_TRIMMING
     grep "^Reads After Trimming" tqc_report.txt | cut -f2 | cut -f1 -d " " | tee MYCOSNP_READS_AFTER_TRIMMING
-    grep "^Reads After Trimming" tqc_report.txt  | awk '{print $5}' | tee MYCOSNP_READS_AFTER_TRIMMING_PERCENT
+    grep "^Reads After Trimming" tqc_report.txt  | awk '{print $5}' | sed -e "s/[()]//g" | tee MYCOSNP_READS_AFTER_TRIMMING_PERCENT
     grep "^Paired Reads After Trimming" tqc_report.txt | cut -f2 | cut -f1 -d " " | tee MYCOSNP_PAIRED_READS_AFTER_TRIMMING
     grep "^Paired Reads After Trimming" tqc_report.txt | cut -f2 | cut -f2 -d " " | sed -e "s/(//" | tee MYCOSNP_PAIRED_READS_AFTER_TRIMMING_PERCENT
     grep "^Unpaired Reads After Trimming" tqc_report.txt | cut -f2 | cut -f1 -d " " | tee MYCOSNP_UNPAIRED_READS_AFTER_TRIMMING

--- a/tasks/task_mycosnp_variants.wdl
+++ b/tasks/task_mycosnp_variants.wdl
@@ -94,7 +94,7 @@ task mycosnp {
     grep "^Average Q Score Before Trimming" tqc_report.txt | cut -f2 | tee MYCOSNP_AVERAGE_Q_SCORE_BEFORE_TRIMMING
     grep "^Reference Length Coverage Before Trimming" tqc_report.txt | cut -f2 | tee MYCOSNP_REFERENCE_LENGTH_COVERAGE_BEFORE_TRIMMING
     grep "^Reads After Trimming" tqc_report.txt | cut -f2 | cut -f1 -d " " | tee MYCOSNP_READS_AFTER_TRIMMING
-    grep "^Reads After Trimming" tqc_report.txt  | awk '{print $4}' | tee MYCOSNP_READS_AFTER_TRIMMING_PERCENT
+    grep "^Reads After Trimming" tqc_report.txt  | awk '{print $5}' | tee MYCOSNP_READS_AFTER_TRIMMING_PERCENT
     grep "^Paired Reads After Trimming" tqc_report.txt | cut -f2 | cut -f1 -d " " | tee MYCOSNP_PAIRED_READS_AFTER_TRIMMING
     grep "^Paired Reads After Trimming" tqc_report.txt | cut -f2 | cut -f2 -d " " | sed -e "s/(//" | tee MYCOSNP_PAIRED_READS_AFTER_TRIMMING_PERCENT
     grep "^Unpaired Reads After Trimming" tqc_report.txt | cut -f2 | cut -f1 -d " " | tee MYCOSNP_UNPAIRED_READS_AFTER_TRIMMING

--- a/tasks/task_mycosnp_variants.wdl
+++ b/tasks/task_mycosnp_variants.wdl
@@ -94,7 +94,7 @@ task mycosnp {
     grep "^Average Q Score Before Trimming" tqc_report.txt | cut -f2 | tee MYCOSNP_AVERAGE_Q_SCORE_BEFORE_TRIMMING
     grep "^Reference Length Coverage Before Trimming" tqc_report.txt | cut -f2 | tee MYCOSNP_REFERENCE_LENGTH_COVERAGE_BEFORE_TRIMMING
     grep "^Reads After Trimming" tqc_report.txt | cut -f2 | cut -f1 -d " " | tee MYCOSNP_READS_AFTER_TRIMMING
-    grep "^Reads After Trimming" tqc_report.txt | cut -f2 | cut -f2 -d " " | tee MYCOSNP_READS_AFTER_TRIMMING_PERCENT
+    grep "^Reads After Trimming" tqc_report.txt | cut -f2 | cut -f2 -d " " | sed -e "s/(//" | tee MYCOSNP_READS_AFTER_TRIMMING_PERCENT
     grep "^Paired Reads After Trimming" tqc_report.txt | cut -f2 | cut -f1 -d " " | tee MYCOSNP_PAIRED_READS_AFTER_TRIMMING
     grep "^Paired Reads After Trimming" tqc_report.txt | cut -f2 | cut -f2 -d " " | sed -e "s/(//" | tee MYCOSNP_PAIRED_READS_AFTER_TRIMMING_PERCENT
     grep "^Unpaired Reads After Trimming" tqc_report.txt | cut -f2 | cut -f1 -d " " | tee MYCOSNP_UNPAIRED_READS_AFTER_TRIMMING

--- a/tests/workflows/test_wf_mycosnp_variants.yml
+++ b/tests/workflows/test_wf_mycosnp_variants.yml
@@ -17,7 +17,7 @@
     - wf_mycosnp_variants_miniwdl
   files:
     - path: miniwdl_run/call-mycosnp/command
-      md5sum: cf9f64912d441893f2d85c3cf23ef95b
+      md5sum: 02ca3cd7f346df3a453c26f5497daae2
     - path: miniwdl_run/call-mycosnp/inputs.json
     - path: miniwdl_run/call-mycosnp/outputs.json
     - path: miniwdl_run/call-mycosnp/stderr.txt
@@ -44,7 +44,7 @@
     - path: miniwdl_run/call-mycosnp/work/MYCOSNP_READS_AFTER_TRIMMING
       md5sum: 5730f3e02f1b09d3e2a673c972d96c55
     - path: miniwdl_run/call-mycosnp/work/MYCOSNP_READS_AFTER_TRIMMING_PERCENT
-      md5sum: 5acd6ae3f246733a2e8e3ad364218579
+      md5sum: 5730f3e02f1b09d3e2a673c972d96c55
     - path: miniwdl_run/call-mycosnp/work/MYCOSNP_READS_MAPPED
       md5sum: 77f22657560ffeab342772dfa7fa7a9c
     - path: miniwdl_run/call-mycosnp/work/MYCOSNP_READS_BEFORE_TRIMMING
@@ -317,7 +317,7 @@
     - path: miniwdl_run/inputs.json
     - path: miniwdl_run/outputs.json
     - path: miniwdl_run/wdl/tasks/task_mycosnp_variants.wdl
-      md5sum: 5bca12c607e2b1e9597b7df42e64cacb
+      md5sum: 7841670fe6da21113119390e145366ef
     - path: miniwdl_run/wdl/tasks/task_versioning.wdl
       md5sum: a17beb7504b76c9074736e5052702230
     - path: miniwdl_run/wdl/workflows/wf_mycosnp_variants.wdl

--- a/tests/workflows/test_wf_mycosnp_variants.yml
+++ b/tests/workflows/test_wf_mycosnp_variants.yml
@@ -17,7 +17,7 @@
     - wf_mycosnp_variants_miniwdl
   files:
     - path: miniwdl_run/call-mycosnp/command
-      md5sum: 07365a61d5b5e2c406859c4445c96a5e
+      md5sum: cf9f64912d441893f2d85c3cf23ef95b
     - path: miniwdl_run/call-mycosnp/inputs.json
     - path: miniwdl_run/call-mycosnp/outputs.json
     - path: miniwdl_run/call-mycosnp/stderr.txt
@@ -44,7 +44,7 @@
     - path: miniwdl_run/call-mycosnp/work/MYCOSNP_READS_AFTER_TRIMMING
       md5sum: 5730f3e02f1b09d3e2a673c972d96c55
     - path: miniwdl_run/call-mycosnp/work/MYCOSNP_READS_AFTER_TRIMMING_PERCENT
-      md5sum: de6e424e822289f8a213e13a035cee9c
+      md5sum: 5acd6ae3f246733a2e8e3ad364218579
     - path: miniwdl_run/call-mycosnp/work/MYCOSNP_READS_MAPPED
       md5sum: 77f22657560ffeab342772dfa7fa7a9c
     - path: miniwdl_run/call-mycosnp/work/MYCOSNP_READS_BEFORE_TRIMMING
@@ -317,7 +317,7 @@
     - path: miniwdl_run/inputs.json
     - path: miniwdl_run/outputs.json
     - path: miniwdl_run/wdl/tasks/task_mycosnp_variants.wdl
-      md5sum: 0f65fa570dfed0f6cf9afb68db255b58
+      md5sum: 5bca12c607e2b1e9597b7df42e64cacb
     - path: miniwdl_run/wdl/tasks/task_versioning.wdl
       md5sum: a17beb7504b76c9074736e5052702230
     - path: miniwdl_run/wdl/workflows/wf_mycosnp_variants.wdl

--- a/tests/workflows/test_wf_mycosnp_variants.yml
+++ b/tests/workflows/test_wf_mycosnp_variants.yml
@@ -17,7 +17,7 @@
     - wf_mycosnp_variants_miniwdl
   files:
     - path: miniwdl_run/call-mycosnp/command
-      md5sum: 02ca3cd7f346df3a453c26f5497daae2
+      md5sum: 058e8266e045d200efd8a42236f12b40
     - path: miniwdl_run/call-mycosnp/inputs.json
     - path: miniwdl_run/call-mycosnp/outputs.json
     - path: miniwdl_run/call-mycosnp/stderr.txt
@@ -42,7 +42,7 @@
     - path: miniwdl_run/call-mycosnp/work/MYCOSNP_AVERAGE_Q_SCORE_BEFORE_TRIMMING
       md5sum: 7db15e04d911a3d11be23b5043e5e10a
     - path: miniwdl_run/call-mycosnp/work/MYCOSNP_READS_AFTER_TRIMMING
-      md5sum: 5730f3e02f1b09d3e2a673c972d96c55
+      md5sum: 5acd6ae3f246733a2e8e3ad364218579
     - path: miniwdl_run/call-mycosnp/work/MYCOSNP_READS_AFTER_TRIMMING_PERCENT
       md5sum: 5730f3e02f1b09d3e2a673c972d96c55
     - path: miniwdl_run/call-mycosnp/work/MYCOSNP_READS_MAPPED
@@ -317,7 +317,7 @@
     - path: miniwdl_run/inputs.json
     - path: miniwdl_run/outputs.json
     - path: miniwdl_run/wdl/tasks/task_mycosnp_variants.wdl
-      md5sum: 7841670fe6da21113119390e145366ef
+      md5sum: ee7fea04c81b357da58323651360f35f
     - path: miniwdl_run/wdl/tasks/task_versioning.wdl
       md5sum: a17beb7504b76c9074736e5052702230
     - path: miniwdl_run/wdl/workflows/wf_mycosnp_variants.wdl

--- a/tests/workflows/test_wf_mycosnp_variants.yml
+++ b/tests/workflows/test_wf_mycosnp_variants.yml
@@ -42,9 +42,9 @@
     - path: miniwdl_run/call-mycosnp/work/MYCOSNP_AVERAGE_Q_SCORE_BEFORE_TRIMMING
       md5sum: 7db15e04d911a3d11be23b5043e5e10a
     - path: miniwdl_run/call-mycosnp/work/MYCOSNP_READS_AFTER_TRIMMING
-      md5sum: 5acd6ae3f246733a2e8e3ad364218579
-    - path: miniwdl_run/call-mycosnp/work/MYCOSNP_READS_AFTER_TRIMMING_PERCENT
       md5sum: 5730f3e02f1b09d3e2a673c972d96c55
+    - path: miniwdl_run/call-mycosnp/work/MYCOSNP_READS_AFTER_TRIMMING_PERCENT
+      md5sum: 5acd6ae3f246733a2e8e3ad364218579
     - path: miniwdl_run/call-mycosnp/work/MYCOSNP_READS_MAPPED
       md5sum: 77f22657560ffeab342772dfa7fa7a9c
     - path: miniwdl_run/call-mycosnp/work/MYCOSNP_READS_BEFORE_TRIMMING


### PR DESCRIPTION
READS_AFTER_TRIMMING_PERCENT had a '(' in the output, use `sed` to remove them akin to what is run for others

- [x] [`mycosnp-variants`](https://app.terra.bio/#workspaces/theiagen-validations/MycoSNP-WDL_Validation/submission_history/e738472d-f748-4ce0-9aa2-813eb20b1509) test successfully outputted correctly formatted reads_after_trimming percent